### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A Model Context Protocol server for interacting with [Babashka](https://github.com/babashka/babashka), a native Clojure interpreter for scripting.
 
+<a href="https://glama.ai/mcp/servers/5x0u155x1h"><img width="380" height="200" src="https://glama.ai/mcp/servers/5x0u155x1h/badge" alt="Babashka Server MCP server" /></a>
+
 ## Features
 
 - Execute Babashka code through MCP tools


### PR DESCRIPTION
This PR adds a badge for the [Babashka MCP Server](https://glama.ai/mcp/servers/5x0u155x1h) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/5x0u155x1h"><img width="380" height="200" src="https://glama.ai/mcp/servers/5x0u155x1h/badge" alt="Babashka Server MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.